### PR TITLE
Add tests for 5-1 and 5-3.

### DIFF
--- a/5/5-1.ipynb
+++ b/5/5-1.ipynb
@@ -51,9 +51,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%solution\n",
     "from math import sqrt, sin, pi\n",
     "print(sqrt(2))\n",
     "print(sin(pi))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%inlinetest AutograderTest_MathImport\n",
+    "\n",
+    "for name in [\"sqrt\", \"sin\", \"pi\"]:\n",
+    "    assert name in globals(), f\"Cannot find {name}, is it imported from the math module?\"\n",
+    "\n",
+    "import math\n",
+    "for symbol, moduleSymbol, name in [(sqrt, math.sqrt, \"sqrt\"), (sin, math.sin, \"sin\"), (pi, math.pi, \"pi\")]:\n",
+    "    assert symbol == moduleSymbol, f\"Found {name} but it seems different to math.{name}, is {name} imported from the math module?\"\n",
+    "\n",
+    "# Double check the symbols by trying to use them.\n",
+    "assert sqrt(2) == math.sqrt(2), f\"sqrt seems to behave differently to math.sqrt, is it imported from the math module?\"\n",
+    "assert sin(pi) == math.sin(math.pi), f\"sin seems to behave differently to math.sin, is it imported from the math module?\"\n"
    ]
   }
  ],

--- a/5/5-3.ipynb
+++ b/5/5-3.ipynb
@@ -60,8 +60,35 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%solution\n",
     "def arange_square_matrix(n):\n",
     "    return np.array([np.arange(i, n+i) for i in range(n)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# %%inlinetest AutograderTest_arange_square_matrix\n",
+    "\n",
+    "assert \"arange_square_matrix\" in globals(), \"Did you define a function named arange_square_matrix?\"\n",
+    "assert str(arange_square_matrix.__class__) == \"<class 'function'>\", f\"Did you define 'arange_square_matrix' as a function? There was a {arange_square_matrix.__class__} instead\"\n",
+    "\n",
+    "def test_arange_square_matrix(n, expected):\n",
+    "    actual = arange_square_matrix(n)\n",
+    "    assert actual is not None, f\"Did you return a value from the function? Called arange_square_matrix({n}), Got {actual}\"\n",
+    "    assert str(actual.__class__) != \"<class 'list'>\", f\"Did you return a numpy array value? Got a Python list instead. You can convert a Python list to a numpy array using np.array\"\n",
+    "    assert str(actual.__class__) == \"<class 'numpy.ndarray'>\", f\"Did you return a numpy array value? Got {actual.__class__} instead\"\n",
+    "    assert len(actual.shape) == 2, f\"Did you return a 2-dimensional array? Got a {len(actual.shape)}-dimensional array instead\"\n",
+    "    assert actual.shape == (n, n), f\"Did you return the array as a square matrix? Called arange_square_matrix({n}). Expected an array with size {n}x{n}, got size {actual.shape[0]}x{actual.shape[1]} instead\"\n",
+    "    assert all(map(all,(expected == actual))), f\"Does the matrix returned have correct values? Called arange_square_matrix({n}).\\n\\nExpected:\\n{expected}\\n\\nGot this instead:\\n{actual}\"\n",
+    "\n",
+    "test_arange_square_matrix(2, np.array([[0, 1], [1, 2]]))\n",
+    "test_arange_square_matrix(5, np.array([[0, 1, 2, 3, 4], [1, 2, 3, 4, 5], [2, 3, 4, 5, 6], [3, 4, 5, 6, 7], [4, 5, 6, 7, 8]]))"
    ]
   }
  ],


### PR DESCRIPTION
Imported symbols are checked in 5-1, haven't found a way to check for previous `print()` output though.

Verified by manually entering some incorrect solutions and running the cells.